### PR TITLE
Don't support uuid on Windows

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -32,7 +32,7 @@ class CZMQConan(ConanFile):
             self.build_requires.add('ninja_installer/1.8.2@bincrafters/stable')
 
     def requirements(self):
-        self.requires.add('zmq/4.2.2@bincrafters/stable')
+        self.requires.add('zmq/4.2.5@bincrafters/stable')
         if self.options.lz4:
             self.requires.add('lz4/1.8.3@bincrafters/stable')
         if self.options.uuid:

--- a/conanfile.py
+++ b/conanfile.py
@@ -26,6 +26,9 @@ class CZMQConan(ConanFile):
         if self.settings.os == "Macos" and self.options.uuid:
             self.output.warn("czmq doesn't support external libuuid on MacOS")
             self.options.uuid = False
+        elif self.settings.os == "Windows" and self.options.uuid:
+            self.output.warn("czmq doesn't support external libuuid on Windows")
+            self.options.uuid = False
 
     def build_requirements(self):
         if not tools.which("ninja") and self.settings.compiler == 'Visual Studio':


### PR DESCRIPTION
czmq is almost ready to be sent to the Conan Center, but it does not work on Windows when the default options is applied:

https://ci.appveyor.com/project/BinCrafters/conan-czmq/builds/23753568/job/9h8bk46n9h6frdaw#L616

Suggestion, force uuid=False when building on Windows.